### PR TITLE
Fix pytest warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 testpaths = impurityModel/test
 python_files = *.py
-python_paths = .


### PR DESCRIPTION
remove python_paths variable in pytest.ini