### PR TITLE
Use mypy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: check check_flake8 check_pylint check_black
+.PHONY: check check_flake8 check_pylint check_black check_mypy
 
-check: check_flake8 check_pylint check_black
+check: check_flake8 check_pylint check_black check_mypy
 
 check_flake8:
 	flake8 .
@@ -10,3 +10,6 @@ check_pylint:
 
 check_black:
 	black . --check
+
+check_mypy:
+	mypy --no-incremental --config-file setup.cfg -p impurityModel

--- a/requirements.in
+++ b/requirements.in
@@ -17,3 +17,4 @@ sphinx==4.1.2
 sphinx-rtd-theme==0.5.2
 flake8-return==1.1.3
 pylint==2.6.0
+mypy==0.931

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,3 +30,19 @@ max-locals=59
 max-returns=3
 # Maximum number of statements in function / method body.
 max-statements=140
+
+
+[mypy]
+namespace_packages = True
+allow_redefinition = True
+# Remove ignore_missing_imports if possible.
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+[mypy-h5py.*]
+ignore_missing_imports = True
+[mypy-scipy.*]
+ignore_missing_imports = True
+[mypy-mpi4py.*]
+ignore_missing_imports = True
+[mypy-sympy.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Enable static type checking with mypy.
By default mypy only checks functions with type-hints. This repository don't have any type-hints yet, but good to have mypy in place if start adding type-hints.