### PR TITLE
Fix sphinx warnings

### DIFF
--- a/doc/sphinx/Makefile
+++ b/doc/sphinx/Makefile
@@ -27,5 +27,4 @@ Makefile:
 # Catch-all target: route all unknown targets to Sphinx using the
 # "make mode" option.
 %: $(BUILD_CONFIG)/index.rst
-	#sphinx-build -M $@ .. $(GEN_DOC) -c . -W -q
-	sphinx-build -M $@ .. $(GEN_DOC) -c . 
+	sphinx-build -M $@ .. $(GEN_DOC) -c . -W -q

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -49,4 +49,3 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]

--- a/impurityModel/ed/average.py
+++ b/impurityModel/ed/average.py
@@ -1,9 +1,5 @@
 """
-average
-=======
-
 Module containing functions for performing averaging.
-
 """
 
 import numpy as np

--- a/impurityModel/ed/create.py
+++ b/impurityModel/ed/create.py
@@ -3,7 +3,8 @@ This module contains functions to create/add an electron to a product state.
 Depending on the representation type of the product state, different functions should be used.
 Supported types are: tuple, str, int, bitarray and bytes.
 
-The ordering convention is such that the normal ordering of a product state is `|psi> = c2 c5 |0>`, (and not `c5 c2 |0>`).
+The ordering convention is such that the normal ordering of a product state is
+`|psi> = c2 c5 |0>`, (and not `c5 c2 |0>`).
 
 """
 

--- a/impurityModel/ed/create.py
+++ b/impurityModel/ed/create.py
@@ -1,13 +1,9 @@
 """
-
-create
-======
-
 This module contains functions to create/add an electron to a product state.
 Depending on the representation type of the product state, different functions should be used.
 Supported types are: tuple, str, int, bitarray and bytes.
 
-The ordering convention is such that the normal ordering of a product state is |psi> = c2 c5 |0>, (and not c5 c2 |0>).
+The ordering convention is such that the normal ordering of a product state is `|psi> = c2 c5 |0>`, (and not `c5 c2 |0>`).
 
 """
 

--- a/impurityModel/ed/finite.py
+++ b/impurityModel/ed/finite.py
@@ -1,10 +1,5 @@
 """
-
-finite
-======
-
 This module contains functions doing the bulk of the calculations.
-
 """
 
 from math import pi, sqrt
@@ -224,8 +219,7 @@ def dc_MLFT(n3d_i, c, Fdd, n2p_i=None, Fpd=None, Gpd=None):
 
 def get_spherical_2_cubic_matrix(spinpol=False, l=2):
     r"""
-    Return unitary ndarray for transforming from spherical
-    to cubic harmonics.
+    Return unitary ndarray for transforming from spherical to cubic harmonics.
 
     Parameters
     ----------
@@ -245,7 +239,7 @@ def get_spherical_2_cubic_matrix(spinpol=False, l=2):
     harmonics :math:`i` to the cubic harmonic :math:`j`:
 
     .. math:: \lvert l_j \rangle  = \sum_{i=0}^4 u_{d,(i,j)}
-    \lvert Y_{d,i} \rangle.
+        \lvert Y_{d,i} \rangle.
 
     """
     if l == 1:
@@ -1035,7 +1029,7 @@ def getDensityMatrixCubic(nBaths, psi):
     densityMatrix : dict
         keys of the form: :math:`((i,si),(j,sj))`.
         values of the form: :math:`\langle psi| c_{jc}^\dagger c_{ic}
-         |psi \rangle`.
+        |psi \rangle`.
 
     """
     # density matrix in spherical harmonics
@@ -1625,11 +1619,11 @@ def get_hamiltonian_matrix_from_h_dict(
     Parameters
     ----------
     h_dict : dict
-        Elements of the form |PS> : {hOp|PS>},
-        where |PS> is a product state,
-        and {hOp|PS>} is a dictionary containing the result of
-        the (Hamiltonian) operator hOp acting on the product state |PS>.
-        The dictionary {hOp|PS>} has product states as keys.
+        Elements of the form `|PS> : {hOp|PS>}`,
+        where `|PS>` is a product state,
+        and `{hOp|PS>}` is a dictionary containing the result of
+        the (Hamiltonian) operator hOp acting on the product state `|PS>`.
+        The dictionary `{hOp|PS>}` has product states as keys.
         h_dict may contain some product states (as keys) that are not
         part of the active basis.
         Also, if parallelization_mode == 'H_build', each product state in
@@ -1704,11 +1698,11 @@ def expand_basis(n_spin_orbitals, h_dict, hOp, basis0, restrictions, paralleliza
     n_spin_orbitals : int
         Total number of spin-orbitals in the system.
     h_dict : dict
-        Elements of the form |PS> : {hOp|PS>},
-        where |PS> is a product state,
-        and {hOp|PS>} is a dictionary containing the result of
-        the (Hamiltonian) operator hOp acting on the product state |PS>.
-        The dictionary {hOp|PS>} has product states as keys.
+        Elements of the form `|PS> : {hOp|PS>}`,
+        where `|PS>` is a product state,
+        and `{hOp|PS>}` is a dictionary containing the result of
+        the (Hamiltonian) operator hOp acting on the product state `|PS>`.
+        The dictionary `{hOp|PS>}` has product states as keys.
         New elements might be added to this variable.
         h_dict may contain some product states (as keys) that will not
         be part of the final active basis.
@@ -1827,11 +1821,11 @@ def expand_basis_and_hamiltonian(
     n_spin_orbitals : int
         Total number of spin-orbitals in the system.
     h_dict : dict
-        Elements of the form |PS> : {hOp|PS>},
-        where |PS> is a product state,
+        Elements of the form `|PS> : {hOp|PS>}`,
+        where `|PS>` is a product state,
         and {hOp|PS>} is a dictionary containing the result of
-        the (Hamiltonian) operator hOp acting on the product state |PS>.
-        The dictionary {hOp|PS>} has product states as keys.
+        the (Hamiltonian) operator hOp acting on the product state `|PS>`.
+        The dictionary `{hOp|PS>}` has product states as keys.
         New elements might be added to this variable.
         h_dict may contain some product states (as keys) that will not
         be part of the final active basis.

--- a/impurityModel/ed/mpi_comm.py
+++ b/impurityModel/ed/mpi_comm.py
@@ -1,10 +1,5 @@
 """
-
-mpi_comm
-========
-
 This module contains help functions for MPI communication.
-
 """
 
 import math

--- a/impurityModel/ed/product_state_representation.py
+++ b/impurityModel/ed/product_state_representation.py
@@ -1,8 +1,4 @@
 """
-
-product_state_representation
-============================
-
 This module contains functions for translating a product state from one format
 to another format. The possible types are:
 tuple, str, int, bitarray and bytes.
@@ -29,7 +25,7 @@ representation.
 The tuple, integer, and the bytes representation needs to know the total number of spin-orbitals in the system.
 
 In the create.py and remove.py modules, the ordering convention is such that this product state example represents:
-|psi> = c2 c5 |0>, (and not c5 c2 |0>).
+`|psi> = c2 c5 |0>`, (and not `c5 c2 |0>`).
 
 """
 

--- a/impurityModel/ed/remove.py
+++ b/impurityModel/ed/remove.py
@@ -1,13 +1,9 @@
 """
-
-remove
-======
-
 This module contains functions to remove/annihilate an electron to a product state.
 Depending on the representation type of the product state, different functions should be used.
 Supported types are: tuple, str, int, bitarray and bytes.
 
-The ordering convention is such that the normal ordering of a product state is |psi> = c2 c5 |0>, (and not c5 c2 |0>).
+The ordering convention is such that the normal ordering of a product state is `|psi> = c2 c5 |0>`, (and not `c5 c2 |0>`).
 
 """
 

--- a/impurityModel/ed/remove.py
+++ b/impurityModel/ed/remove.py
@@ -3,7 +3,8 @@ This module contains functions to remove/annihilate an electron to a product sta
 Depending on the representation type of the product state, different functions should be used.
 Supported types are: tuple, str, int, bitarray and bytes.
 
-The ordering convention is such that the normal ordering of a product state is `|psi> = c2 c5 |0>`, (and not `c5 c2 |0>`).
+The ordering convention is such that the normal ordering of a product state is
+`|psi> = c2 c5 |0>`, (and not `c5 c2 |0>`).
 
 """
 

--- a/impurityModel/ed/spectra.py
+++ b/impurityModel/ed/spectra.py
@@ -1,10 +1,5 @@
 """
-
-spectra
-=======
-
 This module contains functions for calculating various spectra.
-
 """
 
 from math import sqrt
@@ -590,7 +585,7 @@ def getGreen(
     h_dict : dict
         Stores the result of the (Hamiltonian) operator hOp acting
         on individual product states. Information is stored according to:
-        |product state> : H|product state>, where
+        `|product state> : H|product state>`, where
         each product state is represented by an integer, and the result is
         a dictionary (of the format int : complex).
         If present, it may also be updated by this function.
@@ -890,7 +885,7 @@ def getRIXSmap(
     h_dict_ground : dict
         Stores the result of the (Hamiltonian) operator hOp acting
         on individual product states. Information is stored according to:
-        |product state> : H|product state>, where
+        `|product state> : H|product state>`, where
         each product state is represented by an integer, and the result is
         a dictionary (of the format int : complex).
         Only product states without a core hole are stored in this variable.

--- a/impurityModel/test/test_comparison_with_reference.py
+++ b/impurityModel/test/test_comparison_with_reference.py
@@ -1,9 +1,5 @@
 """
-test_comparison_with_reference
-==============================
-
 Module with test comparing new simulations with reference data.
-
 """
 
 

--- a/impurityModel/test/test_product_state_representation.py
+++ b/impurityModel/test/test_product_state_representation.py
@@ -1,9 +1,5 @@
 """
-test_product_state_representation
-=================================
-
 Module with tests of functions in product_state_representation.py.
-
 """
 
 


### PR DESCRIPTION
- Fix Sphinx warnings
- Treat Sphinx warnings as errors. This is enforced by github actions.
- Remove module title in python-files, Sphinx is adding that automatically instead.