### PR TITLE
rewrite create and remove in the integer representation

### DIFF
--- a/.github/workflows/buildci.yml
+++ b/.github/workflows/buildci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         ./install_setup.sh

--- a/.github/workflows/buildci.yml
+++ b/.github/workflows/buildci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install dependencies
       run: |
         ./install_setup.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: check check_ruff check_black check_mypy check_pytype
+.PHONY: check check_ruff check_black check_mypy
 
-check: check_ruff check_black check_mypy check_pytype
+check: check_ruff check_black check_mypy
 
 check_ruff:
 	ruff check .
@@ -10,6 +10,3 @@ check_black:
 
 check_mypy:
 	mypy --no-incremental --config-file setup.cfg -p impurityModel
-
-check_pytype:
-	pytype --verbosity 0 --pythonpath . input impurityModel

--- a/impurityModel/ed/create.py
+++ b/impurityModel/ed/create.py
@@ -55,37 +55,41 @@ def utuple(i, state):
         return (), 0
 
 
-def uint(n_spin_orbitals, i, state):
+def uint(n_spin_orbitals: int, i: int, state: int) -> tuple[int, int]:
     """
     Create electron at orbital i in state.
 
     Parameters
     ----------
-    n_spin_orbitals : int
+    n_spin_orbitals:
         Total number of spin-orbitals in the system.
-    i : int
+    i:
         Spin-orbital index.
-    state : int
+    state:
         Product state.
 
     Returns
     -------
-    stateNew : int
+    stateNew:
         Product state.
-    amp : int
+    amp:
         Amplitude. 0, -1 or 1.
 
     """
-    # String representation of product state.
-    s = psr.int2str(state, n_spin_orbitals)
-    if s[i] == "1":
+    i_right = n_spin_orbitals - 1 - i
+    if state & (1 << i_right):
+        # Spin-orbital is already occupied.
+        # Can't add one more electron in that spin-orbital
         return -1, 0
-    elif s[i] == "0":
-        state_new = state + 2 ** (n_spin_orbitals - i - 1)
-        amp = 1 if s[:i].count("1") % 2 == 0 else -1
-        return state_new, amp
     else:
-        raise Exception("Integer representation of state is wrong.")
+        # Create electron with OR-operator
+        state_new = state | (1 << i_right)
+        # Want to count number of electrons in spin-orbitals with index lower than i.
+        # First right bit-shift to get rid of electrons with index equal or bigger than i.
+        # Then count if number of electrons are even or odd.
+        tmp = state >> (i_right + 1)
+        amp = 1 if tmp.bit_count() % 2 == 0 else -1
+        return state_new, amp
 
 
 def ustr(i, state):

--- a/impurityModel/ed/remove.py
+++ b/impurityModel/ed/remove.py
@@ -79,8 +79,8 @@ def uint(n_spin_orbitals: int, i: int, state: int) -> tuple[int, int]:
     i_right = n_spin_orbitals - 1 - i
     if state & (1 << i_right):
         # Spin-orbital is occupied
-        # Remove electron with XOR-operator
-        state_new = state ^ (1 << i_right)
+        # Remove electron with AND and NOT operators
+        state_new = state & (~(1 << i_right))
         # Want to count number of electrons in spin-orbitals with index lower than i.
         # First right bit-shift to get rid of electrons with index equal or bigger than i.
         # Then count if number of electrons are even or odd.

--- a/impurityModel/ed/remove.py
+++ b/impurityModel/ed/remove.py
@@ -55,37 +55,41 @@ def utuple(i, state):
         return (), 0
 
 
-def uint(n_spin_orbitals, i, state):
+def uint(n_spin_orbitals: int, i: int, state: int) -> tuple[int, int]:
     """
     Remove electron at orbital i in state.
 
     Parameters
     ----------
-    n_spin_orbitals : int
+    n_spin_orbitals:
         Total number of spin-orbitals in the system.
-    i : int
+    i:
         Spin-orbital index
-    state : int
+    state:
         Product state.
 
     Returns
     -------
-    state_new : int
+    state_new:
         Product state
-    amp : int
+    amp:
         Amplitude. 0, -1 or 1.
 
     """
-    # String representation of product state.
-    s = psr.int2str(state, n_spin_orbitals)
-    if s[i] == "0":
-        return -1, 0
-    elif s[i] == "1":
-        state_new = state - 2 ** (n_spin_orbitals - i - 1)
-        amp = 1 if s[:i].count("1") % 2 == 0 else -1
+    i_right = n_spin_orbitals - 1 - i
+    if state & (1 << i_right):
+        # Spin-orbital is occupied
+        # Remove electron with XOR-operator
+        state_new = state ^ (1 << i_right)
+        # Want to count number of electrons in spin-orbitals with index lower than i.
+        # First right bit-shift to get rid of electrons with index equal or bigger than i.
+        # Then count if number of electrons are even or odd.
+        tmp = state >> (i_right + 1)
+        amp = 1 if tmp.bit_count() % 2 == 0 else -1
         return state_new, amp
     else:
-        raise Exception("Integer representation of state is wrong.")
+        # Can't remove since spin-orbital is unoccupied
+        return -1, 0
 
 
 def ustr(i, state):

--- a/impurityModel/ed/remove.py
+++ b/impurityModel/ed/remove.py
@@ -78,8 +78,9 @@ def uint(n_spin_orbitals: int, i: int, state: int) -> tuple[int, int]:
     """
     i_right = n_spin_orbitals - 1 - i
     if state & (1 << i_right):
-        # Spin-orbital is occupied
-        # Remove electron with AND and NOT operators
+        # Spin-orbital is occupied.
+        # Remove electron with AND and NOT operators.
+        # (Instead of the AND and NOT operators one could use the XOR operator)
         state_new = state & (~(1 << i_right))
         # Want to count number of electrons in spin-orbitals with index lower than i.
         # First right bit-shift to get rid of electrons with index equal or bigger than i.

--- a/impurityModel/test/test_create.py
+++ b/impurityModel/test/test_create.py
@@ -1,0 +1,92 @@
+from impurityModel.ed import product_state_representation as psr
+from impurityModel.ed import create
+
+
+def test_create_simple_state():
+    # Start with vaccum state (no electrons)
+    integer = 0
+
+    n_spin_orbitals = 7
+
+    # Create the other representations of the state
+    t = psr.int2tuple(integer, n_spin_orbitals)
+    string = psr.int2str(integer, n_spin_orbitals)
+    bits = psr.int2bitarray(integer, n_spin_orbitals)
+    b = psr.int2bytes(integer, n_spin_orbitals)
+
+    # Create two electrons and get state: |psi> = c2 c5 |0>
+    integer_new, amp = create.uint(n_spin_orbitals, 5, integer)
+    assert amp == 1
+    integer_new, amp = create.uint(n_spin_orbitals, 2, integer_new)
+    assert amp == 1
+    assert psr.int2tuple(integer_new, n_spin_orbitals) == (2, 5)
+
+    t_new, amp = create.utuple(5, t)
+    assert amp == 1
+    t_new, amp = create.utuple(2, t_new)
+    assert amp == 1
+    assert t_new == (2, 5)
+
+    string_new, amp = create.ustr(5, string)
+    assert amp == 1
+    string_new, amp = create.ustr(2, string_new)
+    assert amp == 1
+    assert psr.str2tuple(string_new) == (2, 5)
+
+    bits_new = bits.copy()
+    amp = create.ubitarray(5, bits_new)
+    assert amp == 1
+    amp = create.ubitarray(2, bits_new)
+    assert amp == 1
+    assert psr.bitarray2tuple(bits_new) == (2, 5)
+
+    b_new, amp = create.ubytes(n_spin_orbitals, 5, b)
+    assert amp == 1
+    b_new, amp = create.ubytes(n_spin_orbitals, 2, b_new)
+    assert amp == 1
+    assert psr.bytes2tuple(b_new, n_spin_orbitals) == (2, 5)
+
+    # Check that get a negative sign when create electron at spin-orbital 3,
+    # since there is an odd number of eletrons with lower spin-orbital index (one electron in spin-orbital 2)
+
+    integer_new, amp = create.uint(n_spin_orbitals, 3, integer_new)
+    assert amp == -1
+    assert psr.int2tuple(integer_new, n_spin_orbitals) == (2, 3, 5)
+
+    t_new, amp = create.utuple(3, t_new)
+    assert amp == -1
+    assert t_new == (2, 3, 5)
+
+    string_new, amp = create.ustr(3, string_new)
+    assert amp == -1
+    assert psr.str2tuple(string_new) == (2, 3, 5)
+
+    amp = create.ubitarray(3, bits_new)
+    assert amp == -1
+    assert psr.bitarray2tuple(bits_new) == (2, 3, 5)
+
+    b_new, amp = create.ubytes(n_spin_orbitals, 3, b_new)
+    assert amp == -1
+    assert psr.bytes2tuple(b_new, n_spin_orbitals) == (2, 3, 5)
+
+    # Check that get zero amplitude when create electron at spin-orbital 3
+
+    integer_new, amp = create.uint(n_spin_orbitals, 3, integer_new)
+    assert amp == 0
+    assert integer_new == -1
+
+    t_new, amp = create.utuple(3, t_new)
+    assert amp == 0
+    assert t_new == ()
+
+    string_new, amp = create.ustr(3, string_new)
+    assert amp == 0
+    assert string_new == ""
+
+    amp = create.ubitarray(3, bits_new)
+    assert amp == 0
+    assert psr.bitarray2tuple(bits_new) == (2, 3, 5)
+
+    b_new, amp = create.ubytes(n_spin_orbitals, 3, b_new)
+    assert amp == 0
+    assert psr.bytes2tuple(b_new, n_spin_orbitals) == (2, 3, 5)

--- a/impurityModel/test/test_create.py
+++ b/impurityModel/test/test_create.py
@@ -1,5 +1,5 @@
-from impurityModel.ed import product_state_representation as psr
 from impurityModel.ed import create
+from impurityModel.ed import product_state_representation as psr
 
 
 def test_create_simple_state():

--- a/impurityModel/test/test_remove.py
+++ b/impurityModel/test/test_remove.py
@@ -1,5 +1,5 @@
-from impurityModel.ed import product_state_representation as psr
 from impurityModel.ed import create, remove
+from impurityModel.ed import product_state_representation as psr
 
 
 def test_remove_simple_state():

--- a/impurityModel/test/test_remove.py
+++ b/impurityModel/test/test_remove.py
@@ -1,0 +1,73 @@
+from impurityModel.ed import product_state_representation as psr
+from impurityModel.ed import create, remove
+
+
+def test_remove_simple_state():
+    # Start with vaccum state (no electrons)
+    integer = 0
+
+    n_spin_orbitals = 7
+
+    # Create three electrons and get state: |psi> = c2 c3 c5 |0>
+
+    integer, amp = create.uint(n_spin_orbitals, 5, integer)
+    integer, amp = create.uint(n_spin_orbitals, 3, integer)
+    integer, amp = create.uint(n_spin_orbitals, 2, integer)
+    assert psr.int2tuple(integer, n_spin_orbitals) == (2, 3, 5)
+
+    # Create the other representations of the state
+    t = psr.int2tuple(integer, n_spin_orbitals)
+    string = psr.int2str(integer, n_spin_orbitals)
+    bits = psr.int2bitarray(integer, n_spin_orbitals)
+    b = psr.int2bytes(integer, n_spin_orbitals)
+
+    # Remove an electron in spin-orbital 3, and then in 2, and then 4
+    integer, amp = remove.uint(n_spin_orbitals, 3, integer)
+    assert amp == -1
+    assert psr.int2tuple(integer, n_spin_orbitals) == (2, 5)
+    integer, amp = remove.uint(n_spin_orbitals, 2, integer)
+    assert amp == 1
+    assert psr.int2tuple(integer, n_spin_orbitals) == (5,)
+    integer, amp = remove.uint(n_spin_orbitals, 4, integer)
+    assert amp == 0
+    assert integer == -1
+
+    t, amp = remove.utuple(3, t)
+    assert amp == -1
+    assert t == (2, 5)
+    t, amp = remove.utuple(2, t)
+    assert amp == 1
+    assert t == (5,)
+    t, amp = remove.utuple(4, t)
+    assert amp == 0
+    assert t == ()
+
+    string, amp = remove.ustr(3, string)
+    assert amp == -1
+    assert psr.str2tuple(string) == (2, 5)
+    string, amp = remove.ustr(2, string)
+    assert amp == 1
+    assert psr.str2tuple(string) == (5,)
+    string, amp = remove.ustr(4, string)
+    assert amp == 0
+    assert string == ""
+
+    amp = remove.ubitarray(3, bits)
+    assert amp == -1
+    assert psr.bitarray2tuple(bits) == (2, 5)
+    amp = remove.ubitarray(2, bits)
+    assert amp == 1
+    assert psr.bitarray2tuple(bits) == (5,)
+    amp = remove.ubitarray(4, bits)
+    assert amp == 0
+    assert psr.bitarray2tuple(bits) == (5,)
+
+    b, amp = remove.ubytes(n_spin_orbitals, 3, b)
+    assert amp == -1
+    assert psr.bytes2tuple(b, n_spin_orbitals) == (2, 5)
+    b, amp = remove.ubytes(n_spin_orbitals, 2, b)
+    assert amp == 1
+    assert psr.bytes2tuple(b, n_spin_orbitals) == (5,)
+    b, amp = remove.ubytes(n_spin_orbitals, 4, b)
+    assert amp == 0
+    assert psr.bytes2tuple(b, n_spin_orbitals) == (5,)

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,6 @@ scipy==1.10.1
 sphinx==6.2.1
 sphinx-rtd-theme==1.2.2
 mypy==1.4.1
-pytype==2023.7.28
 sphinx-autodoc-typehints==1.23.0
 ruff==0.0.282
 typeguard==4.1.0


### PR DESCRIPTION
In `master` the integer that represents a product state is converted to a string. Then either remove or create an electron by operating on that string. Finally convert back to an integer. 

In this MR instead stay in the integer representation. Remove and create electrons using bit-operators and the function `.bit_count()` . This is faster and more similar to a fast low-level language implementation. The nice thing with using Python is that the total number of spin-orbitals can be bigger than 64 without overflow.  

`.bit_count()` requires at least python3.10. 

`pytype` does not support python3.11. Since people might want to use that version remove `pytype` from `requirements.in`. `pytype` is not so important anyway.

closes: https://github.com/JohanSchott/impurityModel/issues/46