### PR TITLE
Add unit-tests to applyOp function

### DIFF
--- a/impurityModel/ed/finite.py
+++ b/impurityModel/ed/finite.py
@@ -1313,9 +1313,9 @@ def applyOp(n_spin_orbitals, op, psi, slaterWeightMin=1e-12, restrictions=None, 
 
         process. Examples of possible tuples (and their meanings) are:
 
-        ((i, 'c'))  <-> c_i^dagger
+        ((i, 'c'),)  <-> c_i^dagger
 
-        ((i, 'a'))  <-> c_i
+        ((i, 'a'),)  <-> c_i
 
         ((i, 'c'), (j, 'a'))  <-> c_i^dagger c_j
 

--- a/impurityModel/test/test_applyOp.py
+++ b/impurityModel/test/test_applyOp.py
@@ -1,89 +1,155 @@
-# applyOp(n_spin_orbitals, op, psi, slaterWeightMin=1e-12, restrictions=None, opResult=None)
-# test operator contained two processes
-# test to create one electron in already occupied spin-orbital
-# test to remove one electron in empty spin-orbital
-# test to create and remove from an existing product state.
-# test opResult
-# test restrictions
-
-import numpy as np
-import math
-
-from impurityModel.ed.finite import applyOp
 from impurityModel.ed import product_state_representation as psr
+from impurityModel.ed.finite import applyOp
 
 
 def test_applyOp_create_one_electron_from_vacuum():
     vacuum_as_string = "000000"
     n_spin_orbitals = len(vacuum_as_string)
-    vacuum_as_bytes = psr.str2bytes(vacuum_as_string)
     # Multi-configurational state is a single product state
-    psi = {vacuum_as_bytes: 7}
+    psi = {psr.str2bytes(vacuum_as_string): 7}
     for i in range(n_spin_orbitals):
         op = {((i, "c"),): 9}
         psi_new = applyOp(n_spin_orbitals, op, psi)
-        # Check new multi-configurational state psi_new
-        assert len(psi_new) == 1
-        for state, amp in psi_new.items():
-            assert math.isclose(amp, 7 * 9)
-            state_as_string = psr.bytes2str(state, n_spin_orbitals)
-            assert state_as_string == vacuum_as_string[:i] + "1" + vacuum_as_string[i + 1 :]
+        assert psi_new == {psr.str2bytes(vacuum_as_string[:i] + "1" + vacuum_as_string[i + 1 :]): 7 * 9}
+
+
+def test_applyOp_create_one_electron_from_one_electron_state():
+    product_state = "001000"
+    n_spin_orbitals = len(product_state)
+    # Multi-configurational state is a single product state
+    psi = {psr.str2bytes(product_state): 7}
+    for i in range(n_spin_orbitals):
+        op = {((i, "c"),): 9}
+        psi_new = applyOp(n_spin_orbitals, op, psi)
+        index_of_spin_orbital_with_one_electron_already = 2
+        if i == index_of_spin_orbital_with_one_electron_already:
+            # Can not put two electrons in the same spin orbital
+            assert psi_new == {}
+        else:
+            amp = 7 * 9 * (2 * (i < index_of_spin_orbital_with_one_electron_already) - 1)
+            assert psi_new == {psr.str2bytes(product_state[:i] + "1" + product_state[i + 1 :]): amp}
 
 
 def test_applyOp_create_two_electrons_from_vacuum():
     vacuum_as_string = "000000"
     n_spin_orbitals = len(vacuum_as_string)
-    vacuum_as_bytes = psr.str2bytes(vacuum_as_string)
     # Multi-configurational state is a single product state
-    psi = {vacuum_as_bytes: 7}
+    psi = {psr.str2bytes(vacuum_as_string): 7}
     for i in range(n_spin_orbitals):
         for j in range(n_spin_orbitals):
             op = {((i, "c"), (j, "c")): 9}
             psi_new = applyOp(n_spin_orbitals, op, psi)
-            # Check new multi-configurational state psi_new
             if i == j:
                 # Can not put two electrons in the same spin orbital
                 assert psi_new == {}
             else:
-                assert len(psi_new) == 1
-                for state, amp in psi_new.items():
-                    assert math.isclose(amp, 7 * 9 * (2 * (i < j) - 1))
-                    state_as_string = psr.bytes2str(state, n_spin_orbitals)
-                    a, b = min(i, j), max(i, j)
-                    assert (
-                        state_as_string
-                        == vacuum_as_string[:a] + "1" + vacuum_as_string[a + 1 : b] + "1" + vacuum_as_string[b + 1 :]
-                    )
+                a, b = min(i, j), max(i, j)
+                product_state = psr.str2bytes(
+                    vacuum_as_string[:a] + "1" + vacuum_as_string[a + 1 : b] + "1" + vacuum_as_string[b + 1 :]
+                )
+                amp = 7 * 9 * (2 * (i < j) - 1)
+                assert psi_new == {product_state: amp}
 
 
 def test_applyOp_two_creation_processes_from_vacuum():
     vacuum_as_string = "000000"
     n_spin_orbitals = len(vacuum_as_string)
-    vacuum_as_bytes = psr.str2bytes(vacuum_as_string)
     # Multi-configurational state is a single product state
-    psi = {vacuum_as_bytes: 7}
+    psi = {psr.str2bytes(vacuum_as_string): 7}
     for i in range(n_spin_orbitals):
         for j in range(n_spin_orbitals):
             if i == j:
                 continue
             op = {((i, "c"),): 9, ((j, "c"),): 11}
             psi_new = applyOp(n_spin_orbitals, op, psi)
-            # Check new multi-configurational state psi_new
-            assert len(psi_new) == 2
-            for state, amp in psi_new.items():
-                state_as_string = psr.bytes2str(state, n_spin_orbitals)
-                if amp == 7 * 9:
-                    a = i
-                elif amp == 7 * 11:
-                    a = j
-                else:
-                    raise ValueError(f"{amp = }, {state_as_string = }")
-                assert state_as_string == vacuum_as_string[:a] + "1" + vacuum_as_string[a + 1 :]
+            assert psi_new == {
+                psr.str2bytes(vacuum_as_string[:i] + "1" + vacuum_as_string[i + 1 :]): 7 * 9,
+                psr.str2bytes(vacuum_as_string[:j] + "1" + vacuum_as_string[j + 1 :]): 7 * 11,
+            }
 
 
-def main():
-    test_applyOp_create_from_vacuum()
+def test_applyOp_remove_one_electron_from_vacuum():
+    vacuum_as_string = "000000"
+    n_spin_orbitals = len(vacuum_as_string)
+    # Multi-configurational state is a single product state
+    psi = {psr.str2bytes(vacuum_as_string): 7}
+    for i in range(n_spin_orbitals):
+        op = {((i, "a"),): 9}
+        psi_new = applyOp(n_spin_orbitals, op, psi)
+        # Can't remove an electron from un-occupied spin-orbital
+        assert psi_new == {}
 
 
-if __name__ == "__main__":
-    main()
+def test_applyOp_two_processes_but_same_final_state():
+    product_state_as_string = "011000"
+    n_spin_orbitals = len(product_state_as_string)
+    # Multi-configurational state is a single product state
+    psi = {psr.str2bytes(product_state_as_string): 7}
+    op = {((1, "c"), (1, "a")): 9, ((2, "c"), (2, "a")): 11}
+    psi_new = applyOp(n_spin_orbitals, op, psi)
+    assert psi_new == {psr.str2bytes(product_state_as_string): 7 * (9 + 11)}
+
+
+def test_applyOp_opResult():
+    vacuum_as_string = "000000"
+    n_spin_orbitals = len(vacuum_as_string)
+    # Multi-configurational state is a single product state
+    psi = {psr.str2bytes(vacuum_as_string): 7}
+    for i in range(n_spin_orbitals):
+        for j in range(n_spin_orbitals):
+            if i == j:
+                continue
+            op = {((i, "c"),): 9, ((j, "c"),): 11}
+            opResult = {}
+            psi_new = applyOp(n_spin_orbitals, op, psi, opResult=opResult)
+            psi_new_expected = {
+                psr.str2bytes(vacuum_as_string[:i] + "1" + vacuum_as_string[i + 1 :]): 7 * 9,
+                psr.str2bytes(vacuum_as_string[:j] + "1" + vacuum_as_string[j + 1 :]): 7 * 11,
+            }
+            assert psi_new == psi_new_expected
+            # opResult stores how the operator acts on individual product states.
+            assert opResult == {
+                psr.str2bytes(vacuum_as_string): {
+                    psr.str2bytes(vacuum_as_string[:i] + "1" + vacuum_as_string[i + 1 :]): 9,
+                    psr.str2bytes(vacuum_as_string[:j] + "1" + vacuum_as_string[j + 1 :]): 11,
+                }
+            }
+            # Now opResult is available and is used to (quickly) look-up the result
+            psi_new = applyOp(n_spin_orbitals, op, psi, opResult=opResult)
+            assert psi_new == psi_new_expected
+
+            # Store a wrong result in opResult and see that it's used instead of op
+            opResult = {psr.str2bytes(vacuum_as_string): {psr.str2bytes(n_spin_orbitals * "1"): 2}}
+            psi_new = applyOp(n_spin_orbitals, op, psi, opResult=opResult)
+            assert psi_new == {psr.str2bytes(n_spin_orbitals * "1"): 7 * 2}
+
+
+def test_applyOp_restrictions():
+    # Specify one restriction of the occupation (for each product state)
+    spin_orbital_indices = frozenset([1, 4, 5])
+    occupation_lower_and_upper_limits = (0, 1)
+    restrictions = {spin_orbital_indices: occupation_lower_and_upper_limits}
+
+    vacuum_as_string = "000000"
+    n_spin_orbitals = len(vacuum_as_string)
+    # Multi-configurational state is a single product state
+    psi = {psr.str2bytes(vacuum_as_string): 7}
+    for i in range(n_spin_orbitals):
+        for j in range(n_spin_orbitals):
+            op = {((i, "c"), (j, "c")): 9}
+            psi_new = applyOp(n_spin_orbitals, op, psi, restrictions=restrictions)
+            # Sanity check psi_new
+            if i == j:
+                # Never can not put two electrons in the same spin orbital
+                assert psi_new == {}
+            elif i in spin_orbital_indices and j in spin_orbital_indices:
+                # The specified restrictions allow max one electron in spin-orbitals
+                # with indices specified by the variable indices.
+                assert psi_new == {}
+            else:
+                a, b = min(i, j), max(i, j)
+                product_state = psr.str2bytes(
+                    vacuum_as_string[:a] + "1" + vacuum_as_string[a + 1 : b] + "1" + vacuum_as_string[b + 1 :]
+                )
+                amp = 7 * 9 * (2 * (i < j) - 1)
+                assert psi_new == {product_state: amp}

--- a/impurityModel/test/test_applyOp.py
+++ b/impurityModel/test/test_applyOp.py
@@ -30,7 +30,7 @@ def test_applyOp_create_one_electron_from_one_electron_state():
             assert psi_new == {psr.str2bytes(product_state[:i] + "1" + product_state[i + 1 :]): amp}
 
 
-def test_applyOp_create_two_electrons_from_vacuum():
+def test_applyOp_create_two_electrons():
     vacuum_as_string = "000000"
     n_spin_orbitals = len(vacuum_as_string)
     # Multi-configurational state is a single product state
@@ -51,7 +51,7 @@ def test_applyOp_create_two_electrons_from_vacuum():
                 assert psi_new == {product_state: amp}
 
 
-def test_applyOp_two_creation_processes_from_vacuum():
+def test_applyOp_two_creation_processes():
     vacuum_as_string = "000000"
     n_spin_orbitals = len(vacuum_as_string)
     # Multi-configurational state is a single product state
@@ -68,7 +68,7 @@ def test_applyOp_two_creation_processes_from_vacuum():
             }
 
 
-def test_applyOp_remove_one_electron_from_vacuum():
+def test_applyOp_remove_one_electron():
     vacuum_as_string = "000000"
     n_spin_orbitals = len(vacuum_as_string)
     # Multi-configurational state is a single product state

--- a/impurityModel/test/test_applyOp.py
+++ b/impurityModel/test/test_applyOp.py
@@ -1,0 +1,89 @@
+# applyOp(n_spin_orbitals, op, psi, slaterWeightMin=1e-12, restrictions=None, opResult=None)
+# test operator contained two processes
+# test to create one electron in already occupied spin-orbital
+# test to remove one electron in empty spin-orbital
+# test to create and remove from an existing product state.
+# test opResult
+# test restrictions
+
+import numpy as np
+import math
+
+from impurityModel.ed.finite import applyOp
+from impurityModel.ed import product_state_representation as psr
+
+
+def test_applyOp_create_one_electron_from_vaccum():
+    vaccum_as_string = "000000"
+    n_spin_orbitals = len(vaccum_as_string)
+    vaccum_as_bytes = psr.str2bytes(vaccum_as_string)
+    # Multi-configurational state is a single product state
+    psi = {vaccum_as_bytes: 7}
+    for i in range(n_spin_orbitals):
+        op = {((i, "c"),): 9}
+        psi_new = applyOp(n_spin_orbitals, op, psi)
+        # Check new multi-configurational state psi_new
+        assert len(psi_new) == 1
+        for state, amp in psi_new.items():
+            assert math.isclose(amp, 7 * 9)
+            state_as_string = psr.bytes2str(state, n_spin_orbitals)
+            assert state_as_string == vaccum_as_string[:i] + "1" + vaccum_as_string[i + 1 :]
+
+
+def test_applyOp_create_two_electrons_from_vaccum():
+    vaccum_as_string = "000000"
+    n_spin_orbitals = len(vaccum_as_string)
+    vaccum_as_bytes = psr.str2bytes(vaccum_as_string)
+    # Multi-configurational state is a single product state
+    psi = {vaccum_as_bytes: 7}
+    for i in range(n_spin_orbitals):
+        for j in range(n_spin_orbitals):
+            op = {((i, "c"), (j, "c")): 9}
+            psi_new = applyOp(n_spin_orbitals, op, psi)
+            # Check new multi-configurational state psi_new
+            if i == j:
+                # Can not put two electrons in the same spin orbital
+                assert psi_new == {}
+            else:
+                assert len(psi_new) == 1
+                for state, amp in psi_new.items():
+                    assert math.isclose(amp, 7 * 9 * (2 * (i < j) - 1))
+                    state_as_string = psr.bytes2str(state, n_spin_orbitals)
+                    a, b = min(i, j), max(i, j)
+                    assert (
+                        state_as_string
+                        == vaccum_as_string[:a] + "1" + vaccum_as_string[a + 1 : b] + "1" + vaccum_as_string[b + 1 :]
+                    )
+
+
+def test_applyOp_two_creation_processes_from_vaccum():
+    vaccum_as_string = "000000"
+    n_spin_orbitals = len(vaccum_as_string)
+    vaccum_as_bytes = psr.str2bytes(vaccum_as_string)
+    # Multi-configurational state is a single product state
+    psi = {vaccum_as_bytes: 7}
+    for i in range(n_spin_orbitals):
+        for j in range(n_spin_orbitals):
+            if i == j:
+                continue
+            op = {((i, "c"),): 9, ((j, "c"),): 11}
+            psi_new = applyOp(n_spin_orbitals, op, psi)
+            # Check new multi-configurational state psi_new
+            assert len(psi_new) == 2
+            for state, amp in psi_new.items():
+                state_as_string = psr.bytes2str(state, n_spin_orbitals)
+                if amp == 7 * 9:
+                    a = i
+                elif amp == 7 * 11:
+                    a = j
+                else:
+                    raise ValueError(f"{amp = }, {state_as_string = }")
+                assert state_as_string == vaccum_as_string[:a] + "1" + vaccum_as_string[a + 1 :]
+
+
+def main():
+    test_applyOp_create_from_vaccum()
+
+
+if __name__ == "__main__":
+    main()

--- a/impurityModel/test/test_applyOp.py
+++ b/impurityModel/test/test_applyOp.py
@@ -13,12 +13,12 @@ from impurityModel.ed.finite import applyOp
 from impurityModel.ed import product_state_representation as psr
 
 
-def test_applyOp_create_one_electron_from_vaccum():
-    vaccum_as_string = "000000"
-    n_spin_orbitals = len(vaccum_as_string)
-    vaccum_as_bytes = psr.str2bytes(vaccum_as_string)
+def test_applyOp_create_one_electron_from_vacuum():
+    vacuum_as_string = "000000"
+    n_spin_orbitals = len(vacuum_as_string)
+    vacuum_as_bytes = psr.str2bytes(vacuum_as_string)
     # Multi-configurational state is a single product state
-    psi = {vaccum_as_bytes: 7}
+    psi = {vacuum_as_bytes: 7}
     for i in range(n_spin_orbitals):
         op = {((i, "c"),): 9}
         psi_new = applyOp(n_spin_orbitals, op, psi)
@@ -27,15 +27,15 @@ def test_applyOp_create_one_electron_from_vaccum():
         for state, amp in psi_new.items():
             assert math.isclose(amp, 7 * 9)
             state_as_string = psr.bytes2str(state, n_spin_orbitals)
-            assert state_as_string == vaccum_as_string[:i] + "1" + vaccum_as_string[i + 1 :]
+            assert state_as_string == vacuum_as_string[:i] + "1" + vacuum_as_string[i + 1 :]
 
 
-def test_applyOp_create_two_electrons_from_vaccum():
-    vaccum_as_string = "000000"
-    n_spin_orbitals = len(vaccum_as_string)
-    vaccum_as_bytes = psr.str2bytes(vaccum_as_string)
+def test_applyOp_create_two_electrons_from_vacuum():
+    vacuum_as_string = "000000"
+    n_spin_orbitals = len(vacuum_as_string)
+    vacuum_as_bytes = psr.str2bytes(vacuum_as_string)
     # Multi-configurational state is a single product state
-    psi = {vaccum_as_bytes: 7}
+    psi = {vacuum_as_bytes: 7}
     for i in range(n_spin_orbitals):
         for j in range(n_spin_orbitals):
             op = {((i, "c"), (j, "c")): 9}
@@ -52,16 +52,16 @@ def test_applyOp_create_two_electrons_from_vaccum():
                     a, b = min(i, j), max(i, j)
                     assert (
                         state_as_string
-                        == vaccum_as_string[:a] + "1" + vaccum_as_string[a + 1 : b] + "1" + vaccum_as_string[b + 1 :]
+                        == vacuum_as_string[:a] + "1" + vacuum_as_string[a + 1 : b] + "1" + vacuum_as_string[b + 1 :]
                     )
 
 
-def test_applyOp_two_creation_processes_from_vaccum():
-    vaccum_as_string = "000000"
-    n_spin_orbitals = len(vaccum_as_string)
-    vaccum_as_bytes = psr.str2bytes(vaccum_as_string)
+def test_applyOp_two_creation_processes_from_vacuum():
+    vacuum_as_string = "000000"
+    n_spin_orbitals = len(vacuum_as_string)
+    vacuum_as_bytes = psr.str2bytes(vacuum_as_string)
     # Multi-configurational state is a single product state
-    psi = {vaccum_as_bytes: 7}
+    psi = {vacuum_as_bytes: 7}
     for i in range(n_spin_orbitals):
         for j in range(n_spin_orbitals):
             if i == j:
@@ -78,11 +78,11 @@ def test_applyOp_two_creation_processes_from_vaccum():
                     a = j
                 else:
                     raise ValueError(f"{amp = }, {state_as_string = }")
-                assert state_as_string == vaccum_as_string[:a] + "1" + vaccum_as_string[a + 1 :]
+                assert state_as_string == vacuum_as_string[:a] + "1" + vacuum_as_string[a + 1 :]
 
 
 def main():
-    test_applyOp_create_from_vaccum()
+    test_applyOp_create_from_vacuum()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add unit-tests to the function `applyOp` in `impurityModel/ed/finite.py`. 

`applyOp` is a cornerstone of this repo.
It applied an operator on a multi-configurational state and returns the resulting multi-configurational state. 

The input operator can be anything (following the syntax: dict(process: process_amplitude))

The input multi-configurational state can be anything (following the syntax: dict(product_state: product_state_probability_amplitude))


 
  